### PR TITLE
extension 'based-on' and extension 'org-image'

### DIFF
--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -284,7 +284,11 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, ExtensionsSaverMixin, 
                 #     raise BadgrValidationError(
                 #         error_code=999,
                 #         error_message=f"extensions @context invalid {ext['@context']}")
-                if ext_name.endswith('ECTSExtension') or ext_name.endswith('StudyLoadExtension') or ext_name.endswith('CategoryExtension') or ext_name.endswith('LevelExtension') or ext_name.endswith('BasedOnExtension'):
+                if (ext_name.endswith('ECTSExtension')
+                or ext_name.endswith('StudyLoadExtension')
+                or ext_name.endswith('CategoryExtension')
+                or ext_name.endswith('LevelExtension')
+                or ext_name.endswith('BasedOnExtension')):
                     is_formal = True
         self.formal = is_formal
         return extensions

--- a/apps/issuer/serializers_v1.py
+++ b/apps/issuer/serializers_v1.py
@@ -284,7 +284,7 @@ class BadgeClassSerializerV1(OriginalJsonSerializerMixin, ExtensionsSaverMixin, 
                 #     raise BadgrValidationError(
                 #         error_code=999,
                 #         error_message=f"extensions @context invalid {ext['@context']}")
-                if ext_name.endswith('ECTSExtension') or ext_name.endswith('StudyLoadExtension') or ext_name.endswith('CategoryExtension') or ext_name.endswith('LevelExtension'):
+                if ext_name.endswith('ECTSExtension') or ext_name.endswith('StudyLoadExtension') or ext_name.endswith('CategoryExtension') or ext_name.endswith('LevelExtension') or ext_name.endswith('BasedOnExtension'):
                     is_formal = True
         self.formal = is_formal
         return extensions

--- a/apps/mainsite/static/extensions/BasedOnExtension/context.json
+++ b/apps/mainsite/static/extensions/BasedOnExtension/context.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "obi": "https://w3id.org/openbadges#",
+    "extensions": "https://w3id.org/openbadges/extensions#",
+    "BasedOn": "extensions:BasedOn"
+  },
+  "obi:validation": [
+    {
+      "obi:validatesType": "extensions:BasedOnExtension",
+      "obi:validationSchema": "http://localhost:8000/static/extensions/BasedOnExtension/schema.json"
+    }
+  ]
+}

--- a/apps/mainsite/static/extensions/BasedOnExtension/schema.json
+++ b/apps/mainsite/static/extensions/BasedOnExtension/schema.json
@@ -8,7 +8,7 @@
       "type": "object",
       "properties": {
         "slug": {
-          "type": "number"
+          "type": "string"
         },
         "issuerSlug": {
           "type": "string"

--- a/apps/mainsite/static/extensions/BasedOnExtension/schema.json
+++ b/apps/mainsite/static/extensions/BasedOnExtension/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Based On Extension",
+  "description": "An extension that allows you to reference the badgeclass on which this badgeclass is based on.",
+  "type": "object",
+  "properties": {
+    "BasedOn": {
+      "type": "object",
+      "required": ["slug", "issuerSlug"],
+      "properties": {
+        "slug": {
+          "type": "number"
+        },
+        "issuerSlug": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": ["BasedOn"]
+}

--- a/apps/mainsite/static/extensions/BasedOnExtension/schema.json
+++ b/apps/mainsite/static/extensions/BasedOnExtension/schema.json
@@ -6,7 +6,6 @@
   "properties": {
     "BasedOn": {
       "type": "object",
-      "required": ["slug", "issuerSlug"],
       "properties": {
         "slug": {
           "type": "number"

--- a/apps/mainsite/static/extensions/LevelExtension/schema.json
+++ b/apps/mainsite/static/extensions/LevelExtension/schema.json
@@ -4,7 +4,7 @@
   "description": "An extension that allows you to add a level to a badgeclass object.",
   "type": "object",
   "properties": {
-    "Category": {
+    "Level": {
       "type": "string"
     }
   },

--- a/apps/mainsite/static/extensions/OrgImageExtension/context.json
+++ b/apps/mainsite/static/extensions/OrgImageExtension/context.json
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "obi": "https://w3id.org/openbadges#",
+    "extensions": "https://w3id.org/openbadges/extensions#",
+    "OrgImage": "extensions:OrgImage"
+  },
+  "obi:validation": [
+    {
+      "obi:validatesType": "extensions:OrgImageExtension",
+      "obi:validationSchema": "http://localhost:8000/static/extensions/OrgImageExtension/schema.json"
+    }
+  ]
+}

--- a/apps/mainsite/static/extensions/OrgImageExtension/schema.json
+++ b/apps/mainsite/static/extensions/OrgImageExtension/schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Original Image Extension",
+  "description": "An extension that allows you to save the original image too, without border.",
+  "type": "object",
+  "properties": {
+    "OrgImage": {
+      "type": "string"
+    }
+  },
+  "required": ["OrgImage"]
+}


### PR DESCRIPTION
The 'based-on' extension saves the slug and issuer-slug of the BadgeClass it was copied from.

The 'org-image' extension saves the original image data without border.

I havent really done any testing yet... Also no type and 'required' checks so far