### PR TITLE
add cors header to media files

### DIFF
--- a/.docker/etc/site.conf
+++ b/.docker/etc/site.conf
@@ -8,6 +8,7 @@ server {
 
     location /media  {
          alias /mediafiles;
+         add_header Access-Control-Allow-Origin "https://mybadges.org";
     }
 
     location /static {


### PR DESCRIPTION
Loading of mediafiles is not handled by Django but by Nginx. The 'django-cors-headers' middleware is therefor not applied to mediafiles. Instead, the cors headers have to be added in the site.conf