### PR TITLE
(chore): Docker Image updates and improvements

### DIFF
--- a/.docker/Dockerfile.dev.api
+++ b/.docker/Dockerfile.dev.api
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8.14-slim-buster
 
 RUN mkdir /badgr_server
 WORKDIR /badgr_server

--- a/.docker/Dockerfile.prod.api
+++ b/.docker/Dockerfile.prod.api
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8.14-slim-buster
 
 RUN mkdir /badgr_server
 WORKDIR /badgr_server

--- a/.docker/Dockerfile.prod.api
+++ b/.docker/Dockerfile.prod.api
@@ -1,9 +1,8 @@
-FROM python:3.8.14-slim-buster
+# Best practies taken from here: https://snyk.io/blog/best-practices-containerizing-python-docker/
 
-RUN mkdir /badgr_server
-WORKDIR /badgr_server
-
-RUN apt-get update && apt-get upgrade -y
+# ------------------------------> Build image
+FROM python:3.8.14-slim-buster as build
+RUN apt-get update
 RUN apt-get install -y default-libmysqlclient-dev \
                        python3-dev \
                        python3-cairo \
@@ -12,12 +11,38 @@ RUN apt-get install -y default-libmysqlclient-dev \
                        libxmlsec1-dev \
                        pkg-config
 
-COPY requirements.txt                   /badgr_server
-COPY manage.py                          /badgr_server
-COPY .docker/etc/uwsgi.ini              /badgr_server
-COPY .docker/etc/wsgi.py                /badgr_server
-COPY apps                               /badgr_server/apps
-COPY .docker/etc/settings_local.py      /badgr_server/apps/mainsite/
+RUN mkdir /badgr_server
+WORKDIR /badgr_server
+RUN python -m venv /badgr_server/venv
+ENV PATH="/badgr_server/venv/bin:$PATH"
 
-RUN pip install uwsgi
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# ------------------------------> Final image
+FROM python:3.8.14-slim-buster
+RUN apt-get update
+RUN apt-get install -y default-libmysqlclient-dev \
+                       python3-cairo \
+                       libxml2
+
+RUN groupadd -g 999 python && \
+    useradd -r -u 999 -g python python
+
+RUN mkdir /badgr_server && chown python:python /badgr_server
+WORKDIR /badgr_server
+
+# Copy installed dependencies
+COPY --chown=python:python --from=build /badgr_server/venv /badgr_server/venv
+
+# Copy everything related Django stuff
+COPY --chown=python:python  manage.py                          .
+COPY --chown=python:python  .docker/etc/uwsgi.ini              .
+COPY --chown=python:python  .docker/etc/wsgi.py                .
+COPY --chown=python:python  apps                               ./apps
+COPY --chown=python:python  .docker/etc/settings_local.py      ./apps/mainsite/
+
+USER 999
+
+ENV PATH="/badgr_server/venv/bin:$PATH"
+CMD ["uwsgi","--socket", "sock/app.sock", "--ini", "uwsgi.ini"]

--- a/.docker/etc/uwsgi.ini
+++ b/.docker/etc/uwsgi.ini
@@ -7,3 +7,5 @@ threads=2
 chdir=/badgr_server
 module=wsgi:application
 vacuum=true
+gid=999
+uid=999

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Badgr was developed by [Concentric Sky](https://concentricsky.com), starting in 
 Badgr-server hosts standard-compliant endpoints that implement the
 [Open Badges 2.0 specification](https://openbadgespec.org). For each of the core Open Badges objects Issuer, BadgeClass
 and Assertion, there is a standards-compliant public JSON endpoint handled by the Django application as well as an image
-redirect path. 
+redirect path.
 
 Each JSON endpoint, such as `/public/assertions/{entity_id}`, performs content negotiation. It will return a
 standardized JSON-LD payload when the path is requested with no `Accept` header or when JSON payloads are requested.
 Additionally, User-Agent detection allows bots attempting to render a preview card for social sharing to access a clean
 HTML response that includes [Open Graph](https://ogp.me/) meta tags. Other clients requesting `text/html` will receive
 a redirect to the corresponding public route on the UI application that runs in parallel to Badgr-server where humans
-can be presented with a representation of the badge data in their browser. 
+can be presented with a representation of the badge data in their browser.
 
 Each image endpoint typically redirects to an image within the associated storage system. The system can convert from
 SVG to PNG and adapt images to a common "wide" radio for the images needed for card-based previews in many social
@@ -34,20 +34,20 @@ Prerequisites:
 
 Copy the example development settings:
   * `cp .docker/etc/settings_local.dev.py.example .docker/etc/settings_local.dev.py`
-    
+
 **NOTE**: you *may* wish to copy and edit the production config. See Running the Django Server in "Production" below for more details.
   * `cp .docker/etc/settings_local.prod.py.example .docker/etc/settings_local.prod.py`
 
 ### Customize local settings to your environment
-    
+
 Edit the `settings_local.dev.py` and/or `settings_local.prod.py` to adjust the following settings:
 * Set `DEFAULT_FROM_EMAIL` to an address, for instance `"noreply@localhost"`
     * The default `EMAIL_BACKEND= 'django.core.mail.backends.console.EmailBackend'` will log email content to console, which is often adequate for development. Other options are available. See Django docs for [sending email](https://docs.djangoproject.com/en/1.11/topics/email/).
 * Set `SECRET_KEY` and `UNSUBSCRIBE_SECRET_KEY` each to (different) cryptographically secure random values.
     * Generate values with: `python -c "import base64; import os; print(base64.b64encode(os.urandom(30)).decode('utf-8'))"`
-* Set `AUTHCODE_SECRET_KEY` to a 32 byte url-safe base64-encoded random string. This key is used for symmetrical encryption of authentication tokens.  If not defined, services like OAuth will not work. 
+* Set `AUTHCODE_SECRET_KEY` to a 32 byte url-safe base64-encoded random string. This key is used for symmetrical encryption of authentication tokens.  If not defined, services like OAuth will not work.
     * Generate a value with: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key())"`
-  
+
 #### Additional configuration options
 Set or adjust these values in your `settings_local.dev.py` and/or `settings_local.prod.py` file to further configure the application to your specific needs.
 * `HELP_EMAIL`:
@@ -62,10 +62,10 @@ Set or adjust these values in your `settings_local.dev.py` and/or `settings_loca
   - Allows you to turn off signup through the API by setting to `False` if you would like to use Badgr for only single-account use or to manually create all users in `/staff`. The default is `True` (signup API is enabled). UX is not well-supported in the `/staff` interface.
 * `DEFAULT_FILE_STORAGE` and `MEDIA_URL`:
   - Django supports various backends for storing media, as applicable for your deployment strategy. See Django docs on the [file storage API](https://docs.djangoproject.com/en/1.11/ref/files/storage/)
- 
+
 ### Running the Django Server in Development
 
-For development, it is usually best to run the project with the builtin django development server. The 
+For development, it is usually best to run the project with the builtin django development server. The
 development server will reload itself in the docker container whenever changes are made to the code in `apps/`.
 
 To run the project with docker in a development mode:
@@ -81,7 +81,7 @@ To run the project with docker in a development mode:
 By default `docker-compose` will look for a `docker-compose.yml` for instructions of what to do. This file
 is the development (and thus default) config for `docker-compose`.
 
-If you'd like to run the project with a more production-like setup, you can specify the `docker-compose.prod.yml` 
+If you'd like to run the project with a more production-like setup, you can specify the `docker-compose.prod.yml`
 file. This setup **copies** the project code in (instead of mirroring) and uses nginx with uwsgi to run django.
 
 * `docker-compose -f docker-compose.prod.yml up -d` - build and get django and other components (production mode)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,15 +1,28 @@
 # A dockerized badgr-server stack to emulate a production build
-version: "3.3"
+version: "3.9"
 services:
+
+  change-ownership:
+    image: alpine
+    user: root
+    group_add:
+      - "999"
+    volumes:
+      - badgr_server_api_sock:/badgr_server/sock
+      - badgr_server_staticfiles:/badgr_server/staticfiles
+      - badgr_server_mediafiles:/badgr_server/mediafiles
+    command: chown -R 999:999 /badgr_server/sock /badgr_server/staticfiles /badgr_server/mediafiles
+
   # this container copies in the project code and runs the app with uwsgi
   api:
     build:
       context: .
       dockerfile: .docker/Dockerfile.prod.api
     depends_on:
-      - "db"
-      - "memcached"
-    command: uwsgi --socket sock/app.sock --ini uwsgi.ini
+      db:
+        condition: service_started
+      memcached:
+        condition: service_started
     volumes:
       - badgr_server_api_sock:/badgr_server/sock
       - badgr_server_mediafiles:/badgr_server/mediafiles
@@ -45,6 +58,8 @@ services:
     build:
       context: .
       dockerfile: .docker/Dockerfile.nginx
+    group_add:
+      - "999"
     volumes:
       - badgr_server_api_sock:/sock
       - badgr_server_mediafiles:/mediafiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   # this container runs mysql (database)
   db:
     image: mysql:5.6.39
+    # platform: linux/amd64 comment in if you are on Apple Silicon
     volumes:
       - badgr_server_dev_db:/var/lib/mysql:rw
       - ./.docker/etc/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,5 +104,6 @@ xmlsec==1.3.3
 
 #locking a dependency lib
 requests-cache==0.5.2
+importlib-resources==5.10.0 # Normally v6.0.1 is installed but Django is not working with it
 
 geopy==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,3 +107,4 @@ requests-cache==0.5.2
 importlib-resources==5.10.0 # Normally v6.0.1 is installed but Django is not working with it
 
 geopy==2.2.0
+uwsgi


### PR DESCRIPTION
Not sure if you are interested in these changes to the Docker production image.

First of all in both `prod` and `dev` Docker image the base image is locked to a specific version. In this case it is `python:3.8.14`. More or less one year ago the Debian base image was changed for the before used tag `python:3.8-slim`.
Without locking the version to this specific base image I was not able to get the project started. Furthermore I had to pin the version of `importlib-resources` to `5.10.0` in the requirements.txt. Also it is one best practices to use an explicit and deterministic base image.

Checkout this blog post: https://snyk.io/blog/best-practices-containerizing-python-docker/

Also the production Docker image was adjusted with the best practices mentioned in the blog post. It includes the following things:
- multi-stage builds
- move command from docker-compose to base image
- run container with least privileges

Within the final Docker image (last multi-stage) a new group and user called python with id 999 is created and used as the main user to run the Django application. To make it work the group must be added to the `nginx` service because they share named volumes.
In the docker compose file the service called `change-ownership` will just run at startup and will change the ownership of the named volumes to the 999 group. By default all named volumes are owned by `root`. Check this blog post https://devcoops.com/docker-compose-and-named-volumes-as-non-root-user/

